### PR TITLE
Fix: Migrations fail when addIndex() or removeIndex() is called in a migration chain.

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -140,7 +140,7 @@ class Migration
      * @param string $name
      * @param array  $columns
      * @param array  $options
-     * @return Migration
+     * @return $this
      */
     public function addIndex(string $name, array $columns, array $options = []): self
     {
@@ -149,6 +149,8 @@ class Migration
         }
 
         $this->indexOperations[] = new IndexOperation($name, IndexOperation::ADD, $columns, $options);
+
+        return $this;
     }
 
     /**
@@ -168,6 +170,8 @@ class Migration
         }
 
         $this->indexOperations[] = new IndexOperation($name, IndexOperation::DROP, [], []);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Migrations fail when addIndex() or removeIndex() is called in the migration definition chain.

I.E. return \Exo\Migration::create('changelog')
    ->addColumn('id', ['type' => 'uuid', 'primary' => true])
    ->addColumn('created_by', ['type' => 'uuid', 'null' => true])
    ->addIndex('created_by', ['created_by']);

The addIndex() and removeIndex() methods indicate that they are meant to return $this to support call chaining in doc blocks, but return $this; was not implemented.

This commit resolves the issue.