### PR TITLE
Upgrade Travis CI tests to use correct version of PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php: 7.3
 services: mysql
 
 before_script:
-  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-6.5.14.phar
+  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-8.3.4.phar
   - composer install --no-interaction --prefer-source
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
 


### PR DESCRIPTION
This PR updates Travis CI to use the same version of PHPUnit as outlined in `composer.json`.