### PR TITLE
Add better support for date columns

### DIFF
--- a/doc/03-testing.md
+++ b/doc/03-testing.md
@@ -2,7 +2,7 @@
 
 ## Data Source Config
 
-- Copy `test/db.yml.example` to `tests/db.yml`
+- Copy `tests/db.yml.example` to `tests/db.yml`
 - Add the credentials for your data source(s)
 
 ## Create Database

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -153,6 +153,14 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
         }
 
+        if ($options['default'] ?? false) {
+            $definition .= sprintf(' DEFAULT %s', $options['default']);
+        }
+
+        if ($options['update'] ?? false) {
+            $definition .= sprintf(' ON UPDATE %s', $options['update']);
+        }
+
         return $definition;
     }
 

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -137,6 +137,10 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= ' NOT NULL';
         }
 
+        if ($options['null'] ?? false) {
+            $definition .= ' NULL';
+        }
+
         if ($options['primary'] ?? false) {
             $definition .= ' PRIMARY KEY';
         }

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -25,7 +25,7 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
-                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']])),
+                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']]),
                     new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -25,12 +25,13 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
-                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']])
+                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']])),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])
                 ]),
                 'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `username` VARCHAR(64) NOT NULL, ' .
-                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), INDEX `username` (`username`) UNIQUE);'
+                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
             ],
             [
                 new TableOperation('users', TableOperation::ALTER, [

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -34,6 +34,41 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                 '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
             ],
             [
+                new TableOperation('users', TableOperation::CREATE, [
+                    new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP'])
+                ], []),
+                'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP);'
+            ],
+            [
+                new TableOperation('users', TableOperation::CREATE, [
+                    new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'update' => 'CURRENT_TIMESTAMP'])
+                ], []),
+                'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `created_at` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP);'
+            ],
+            [
+                new TableOperation('users', TableOperation::CREATE, [
+                    new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'null' => true])
+                ], []),
+                'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `created_at` TIMESTAMP NULL);'
+            ],
+            [
+                new TableOperation('users', TableOperation::CREATE, [
+                    new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'null' => false])
+                ], []),
+                'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `created_at` TIMESTAMP NOT NULL);'
+            ],
+            [
+                new TableOperation('users', TableOperation::CREATE, [
+                    new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
+                    new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp'])
+                ], []),
+                'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `created_at` TIMESTAMP);'
+            ],
+            [
                 new TableOperation('users', TableOperation::ALTER, [
                     new ColumnOperation('meta', ColumnOperation::ADD, ['type' => 'json', 'after' => 'password']),
                     new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),


### PR DESCRIPTION
This PR adds support to the `MySQLStatementBuilder::buildColumn` method for:

- `NULL`
- `DEFAULT`
- `ON UPDATE` . 

Without these, all dates default to the following:

```
return \Exo\Migration::create('changelog')
    ->addColumn('id', ['type' => 'uuid', 'primary' => true])
    ->addColumn('created_at', ['type' => 'timestamp']);


--> `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
```
_(note on the above: this isn't what EXO outputs but MySQL 5.7 seems to default to this)_

Allowing `NULL` to be set, allows the following:

```
return \Exo\Migration::create('changelog')
    ->addColumn('id', ['type' => 'uuid', 'primary' => true])
    ->addColumn('created_at', ['type' => 'timestamp', 'null' => true]);


--> `created_at` TIMESTAMP NULL
```

By allowing `DEFAULT`, stops the `ON UPDATE` from being applied also. 


```
return \Exo\Migration::create('changelog')
    ->addColumn('id', ['type' => 'uuid', 'primary' => true])
    ->addColumn('created_at', ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP']);


--> `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
```

All-in-all this gives much more power over dates. 