### PR TITLE
Implement TEXT data types

### DIFF
--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -125,6 +125,9 @@ class MysqlStatementBuilder extends StatementBuilder
                         'TEXT' => 65535,
                         'TINYTEXT' => 255
                     ];
+                    if ($options['length'] > $sizes['LONGTEXT']) {
+                        throw new \InvalidArgumentException('Invalid length provided for \'text\' column type.');
+                    }
                     foreach ($sizes as $name => $length) {
                         if ($options['length'] >= $length) {
                             return $name;

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -117,6 +117,14 @@ class MysqlStatementBuilder extends StatementBuilder
                 return 'JSON';
             case 'enum':
                 return sprintf("ENUM('%s')", implode("','", $options['values']));
+            case 'tinytext':
+                return 'TINYTEXT';
+            case 'text':
+                return 'TEXT';
+            case 'mediumtext':
+                return 'MEDIUMTEXT';
+            case 'longtext':
+                return 'LONGTEXT';
             default:
                 return parent::buildType($options);
         }

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -123,7 +123,7 @@ class MysqlStatementBuilder extends StatementBuilder
                         'LONGTEXT' => 4294967295,
                         'MEDIUMTEXT' => 16777215,
                         'TEXT' => 65535,
-                        'TINYTEXT' => 255,
+                        'TINYTEXT' => 255
                     ];
                     foreach ($sizes as $name => $length) {
                         if ($options['length'] >= $length) {

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -117,14 +117,21 @@ class MysqlStatementBuilder extends StatementBuilder
                 return 'JSON';
             case 'enum':
                 return sprintf("ENUM('%s')", implode("','", $options['values']));
-            case 'tinytext':
-                return 'TINYTEXT';
             case 'text':
+                if (array_key_exists('length', $options)) {
+                    $sizes = [
+                        'LONGTEXT' => 4294967295,
+                        'MEDIUMTEXT' => 16777215,
+                        'TEXT' => 65535,
+                        'TINYTEXT' => 255,
+                    ];
+                    foreach ($sizes as $name => $length) {
+                        if ($options['length'] >= $length) {
+                            return $name;
+                        }
+                    }
+                }
                 return 'TEXT';
-            case 'mediumtext':
-                return 'MEDIUMTEXT';
-            case 'longtext':
-                return 'LONGTEXT';
             default:
                 return parent::buildType($options);
         }

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -92,4 +92,17 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+
+    public function testInvalidTextLengthThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid length provided for \'text\' column type.');
+
+        $operation = new TableOperation('users', TableOperation::CREATE, [
+            new ColumnOperation('novel', ColumnOperation::ADD, ['type' => 'text', 'length' => 99999999999])
+        ], []);
+
+        $handler = new MysqlStatementBuilder();
+        $handler->build($operation);
+    }
 }

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -26,12 +26,18 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
                     new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']]),
+                    new ColumnOperation('tinytext', ColumnOperation::ADD, ['type' => 'tinytext']),
+                    new ColumnOperation('summary', ColumnOperation::ADD, ['type' => 'text']),
+                    new ColumnOperation('description', ColumnOperation::ADD, ['type' => 'mediumtext']),
+                    new ColumnOperation('novel', ColumnOperation::ADD, ['type' => 'longtext']),
                     new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])
                 ]),
                 'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `username` VARCHAR(64) NOT NULL, ' .
-                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
+                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), ' .
+                '`tinytext` TINYTEXT, `summary` TEXT, `description` MEDIUMTEXT, `novel` LONGTEXT, ' .
+                '`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
             ],
             [
                 new TableOperation('users', TableOperation::CREATE, [

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -26,10 +26,10 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
                     new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']]),
-                    new ColumnOperation('tinytext', ColumnOperation::ADD, ['type' => 'tinytext']),
+                    new ColumnOperation('tinytext', ColumnOperation::ADD, ['type' => 'text', 'length' => 255]),
                     new ColumnOperation('summary', ColumnOperation::ADD, ['type' => 'text']),
-                    new ColumnOperation('description', ColumnOperation::ADD, ['type' => 'mediumtext']),
-                    new ColumnOperation('novel', ColumnOperation::ADD, ['type' => 'longtext']),
+                    new ColumnOperation('description', ColumnOperation::ADD, ['type' => 'text', 'length' => 16777215]),
+                    new ColumnOperation('novel', ColumnOperation::ADD, ['type' => 'text', 'length' => 4294967295]),
                     new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])


### PR DESCRIPTION
This PR implements the four [TEXT data types](https://dev.mysql.com/doc/refman/5.7/en/blob.html) in MySQL.

- `TINYTEXT`
- `TEXT`
- `MEDIUMTEXT`
- `LONGTEXT`

Example usage:

```php
return \Exo\Migration::create('events')
    ->addColumn('id', ['type' => 'uuid', 'primary' => true])
    ->addColumn('description', ['type' => 'text', 'null' => true]);
```