### PR TITLE
Enhance DEFAULT values

### DIFF
--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -157,7 +157,7 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
         }
 
-        if (isset($options['default'])) {
+        if (array_key_exists('default', $options)) {
             $definition .= sprintf(' DEFAULT %s', $this->buildDefaultValue($options['default']));
         }
 

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -194,14 +194,17 @@ class MysqlStatementBuilder extends StatementBuilder
     /**
      * Builds a default.
      *
-     * @param string $value
+     * @param mixed $value
      * @return string
      */
-    protected function buildDefaultValue(string $value): string
+    protected function buildDefaultValue($value): string
     {
-        if (in_array($value, ['CURRENT_TIMESTAMP'])) {
-            return $value;
+        if (is_string($value) && $value !== 'CURRENT_TIMESTAMP') {
+            return sprintf('\'%s\'', $value);
+        } elseif (is_bool($value)) {
+            return (bool) $value ? 1 : 0;
+        } else {
+            return sprintf('%s', $value);
         }
-        return sprintf('\'%s\'', $value);
     }
 }

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -157,7 +157,7 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
         }
 
-        if ($options['default'] ?? false) {
+        if (isset($options['default'])) {
             $definition .= sprintf(' DEFAULT %s', $this->buildDefaultValue($options['default']));
         }
 

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -158,7 +158,7 @@ class MysqlStatementBuilder extends StatementBuilder
         }
 
         if ($options['default'] ?? false) {
-            $definition .= sprintf(' DEFAULT %s', $options['default']);
+            $definition .= sprintf(' DEFAULT %s', $this->buildDefaultValue($options['default']));
         }
 
         if ($options['update'] ?? false) {
@@ -189,5 +189,19 @@ class MysqlStatementBuilder extends StatementBuilder
         }
 
         return $definition;
+    }
+
+    /**
+     * Builds a default.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function buildDefaultValue(string $value): string
+    {
+        if (in_array($value, ['CURRENT_TIMESTAMP'])) {
+            return $value;
+        }
+        return sprintf('\'%s\'', $value);
     }
 }

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -201,8 +201,6 @@ class MysqlStatementBuilder extends StatementBuilder
     {
         if (is_string($value) && $value !== 'CURRENT_TIMESTAMP') {
             return sprintf('\'%s\'', $value);
-        } elseif (is_bool($value)) {
-            return (bool) $value ? 1 : 0;
         } else {
             return sprintf('%s', $value);
         }

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -26,12 +26,15 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
                     new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female'], 'default' => 'male']),
+                    new ColumnOperation('archived', ColumnOperation::ADD, ['type' => 'bool', 'default' => 1]),
+                    new ColumnOperation('status', ColumnOperation::ADD, ['type' => 'string', 'default' => 'draft']),
                     new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])
                 ]),
                 'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `username` VARCHAR(64) NOT NULL, ' .
-                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\') DEFAULT \'male\', `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
+                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\') DEFAULT \'male\', `archived` SMALLINT(1) DEFAULT 1, `status` VARCHAR(255) DEFAULT \'draft\', ' .
+                '`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
             ],
             [
                 new TableOperation('users', TableOperation::CREATE, [

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -25,13 +25,13 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('id', ColumnOperation::ADD, ['type' => 'uuid', 'primary' => true]),
                     new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 64, 'null' => false]),
                     new ColumnOperation('password', ColumnOperation::ADD, ['type' => 'string']),
-                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female']]),
+                    new ColumnOperation('gender', ColumnOperation::ADD, ['type' => 'enum', 'values' => ['male', 'female'], 'default' => 'male']),
                     new ColumnOperation('created_at', ColumnOperation::ADD, ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
                 ], [
                     new IndexOperation('username', IndexOperation::ADD, ['username'], ['unique' => true])
                 ]),
                 'CREATE TABLE `users` (`id` CHAR(36) PRIMARY KEY, `username` VARCHAR(64) NOT NULL, ' .
-                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\'), `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
+                '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\') DEFAULT \'male\', `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
             ],
             [
                 new TableOperation('users', TableOperation::CREATE, [


### PR DESCRIPTION
This PR enhances the way `DEFAULT` values are handled. 

Some DEFAULT values are constants (like `CURRENT_TIMESTAMP`) where others need to be strings. 

MySQL queries need strings wrapped in quotes so I have added a `buildDefaultValue` method to the `MySQLStatementBuilder` to facilitate this transformation.

I had to use `array_key_exists` to check for a `default` key as the existing code didn't allow for 0 or empty values.

Example of a constant:
```php
return \Exo\Migration::create('events')
    ->addColumn('date', ['type' => 'timestamp', 'default' => 'CURRENT_TIMESTAMP'])
```

Example of a string:
```php
return \Exo\Migration::create('events')
    ->addColumn('all_day', ['type' => 'enum', 'values' => [0, 1], 'default' => '0'])
```