### PR TITLE
Enhancement: Add support for view management in migrations

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -21,7 +21,7 @@ class Handler
     /**
      * Handler constructor.
      *
-     * @param PDO    $db
+     * @param PDO     $db
      * @param History $history
      */
     public function __construct(PDO $db, History $history)
@@ -35,7 +35,7 @@ class Handler
      *
      * @param string|null $current
      * @param string|null $target
-     * @param bool $reduce
+     * @param bool        $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
@@ -83,9 +83,9 @@ class Handler
     /**
      * Performs a rollback from current to target version.
      *
-     * @param string $current
+     * @param string      $current
      * @param string|null $target
-     * @param bool $reduce
+     * @param bool        $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -35,8 +35,9 @@ class Handler
      *
      * @param string|null $current
      * @param string|null $target
-     * @param bool        $reduce
+     * @param bool $reduce
      * @return HandlerResult[]
+     * @throws Operation\UnsupportedOperationException
      */
     public function migrate(?string $current, ?string $target, bool $reduce)
     {
@@ -82,10 +83,11 @@ class Handler
     /**
      * Performs a rollback from current to target version.
      *
-     * @param string      $current
+     * @param string $current
      * @param string|null $target
-     * @param bool        $reduce
+     * @param bool $reduce
      * @return HandlerResult[]
+     * @throws Operation\UnsupportedOperationException
      */
     public function rollback(string $current, ?string $target, bool $reduce)
     {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -2,6 +2,7 @@
 
 namespace Exo;
 
+use Exo\Operation\AbstractOperation;
 use Exo\Statement\MysqlStatementBuilder;
 use Exo\Statement\StatementBuilder;
 use PDO;
@@ -39,7 +40,7 @@ class Handler
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function migrate(?string $current, ?string $target, bool $reduce)
+    public function migrate(?string $current, ?string $target, bool $reduce): array
     {
         $versions = $this->history->getVersions();
         $version = null;
@@ -58,26 +59,8 @@ class Handler
 
         // Execute operations
         $operations = $this->history->play($from, $to, $reduce);
-        $results = [];
 
-        foreach ($operations as $offset => $operation) {
-            $sql = $this->getBuilder()->build($operation);
-            $result = $this->db->exec($sql);
-
-            $results[] = new HandlerResult(
-                $reduce ? null : $versions[$offset],
-                $result !== false,
-                $sql,
-                $result === false ? $this->db->errorInfo() : null
-            );
-
-            // Stop migration if there was a failure
-            if ($result === false) {
-                break;
-            }
-        }
-
-        return $results;
+        return $this->processOperations($operations, $versions, $reduce);
     }
 
     /**
@@ -89,7 +72,7 @@ class Handler
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function rollback(string $current, ?string $target, bool $reduce)
+    public function rollback(string $current, ?string $target, bool $reduce): array
     {
         $versions = $this->history->getVersions();
         $from = $target ? array_search($target, $versions) : 0;
@@ -102,9 +85,21 @@ class Handler
         );
 
         $operations = $this->history->rewind(end($versions), reset($versions), $reduce);
-        $results = [];
 
         $versions = array_reverse($versions);
+
+        return $this->processOperations($operations, $versions, $reduce);
+    }
+
+    /**
+     * @param AbstractOperation[] $operations
+     * @param array $versions
+     * @param bool $reduce
+     * @return HandlerResult[]
+     * @throws Operation\UnsupportedOperationException
+     */
+    private function processOperations(array $operations, array $versions, bool $reduce): array {
+        $results = [];
 
         foreach ($operations as $offset => $operation) {
             $sql = $this->getBuilder()->build($operation);
@@ -117,7 +112,7 @@ class Handler
                 $result === false ? $this->db->errorInfo() : null
             );
 
-            // Stop rollback if there was a failure
+            // Stop processing if there was a failure
             if ($result === false) {
                 break;
             }

--- a/src/History.php
+++ b/src/History.php
@@ -92,7 +92,7 @@ class History
      *
      * @param string $from
      * @param string $to
-     * @param bool $reduce
+     * @param bool   $reduce
      * @return TableOperation[]
      * @throws UnsupportedOperationException
      */

--- a/src/Operation/UnsupportedOperationException.php
+++ b/src/Operation/UnsupportedOperationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Exo\Operation;
+
+class UnsupportedOperationException extends \Exception
+{
+    public function __construct(string $className = '')
+    {
+        parent::__construct();
+        $this->message = sprintf('The operation type passed in (%s) is not supported', $className);
+    }
+}

--- a/src/Operation/ViewOperation.php
+++ b/src/Operation/ViewOperation.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Exo\Operation;
+
+class ViewOperation extends AbstractOperation
+{
+    const CREATE = 'create';
+    const ALTER = 'alter';
+    const DROP = 'drop';
+
+    /**
+     * @var string
+     */
+    private $view;
+
+    /**
+     * @var string
+     */
+    private $operation;
+
+    /**
+     * @var string|null
+     */
+    private $body;
+
+    /**
+     * ViewOperation constructor.
+     *
+     * @param string $view
+     * @param string $operation
+     * @param string|null $body
+     */
+    public function __construct(string $view, string $operation, string $body = null)
+    {
+        $this->view = $view;
+        $this->operation = $operation;
+        $this->body = $body;
+    }
+
+    /**
+     * Returns the reverse of the operation.
+     *
+     * @param ViewOperation|null $original
+     * @return static
+     */
+    public function reverse(ViewOperation $original = null): ViewOperation
+    {
+        if ($this->getOperation() === ViewOperation::CREATE) {
+            return new ViewOperation(
+                $this->view,
+                ViewOperation::DROP,
+                null
+            );
+        }
+
+        if ($original && $original->view !== $this->view) {
+            throw new \InvalidArgumentException('Previous operations must apply to the same view.');
+        }
+
+        // Provide the create view operation to reverse a drop
+        if ($this->getOperation() === ViewOperation::DROP) {
+            return $original;
+        }
+
+        return new ViewOperation(
+            $this->view,
+            ViewOperation::ALTER,
+            $original->getBody()
+        );
+    }
+
+    /**
+     * Returns a new operation by applying another operation.
+     *
+     * @param ViewOperation $operation
+     * @return ViewOperation|null
+     */
+    public function apply(ViewOperation $operation)
+    {
+        if ($operation->view !== $this->getView()) {
+            throw new \InvalidArgumentException('Cannot apply operations for a different view.');
+        }
+
+        if ($this->operation === self::DROP) {
+            throw new \InvalidArgumentException('Cannot apply further operations to a dropped view.');
+        }
+
+        if ($this->operation === self::CREATE) {
+            if ($operation->operation === self::CREATE) {
+                throw new \InvalidArgumentException('Cannot recreate an existing view.');
+            }
+
+            // Skip creation of views that will be dropped
+            if ($operation->operation === self::DROP) {
+                return null;
+            }
+        } else if ($operation->operation === self::DROP) {
+
+            // Skip modification of views that will be dropped
+            return $operation;
+        }
+
+        return new ViewOperation($this->view, $this->operation, $operation->body);
+    }
+
+    /**
+     * Returns the view name.
+     *
+     * @return string
+     */
+    public function getView(): string
+    {
+        return $this->view;
+    }
+
+    /**
+     * Returns the operation.
+     *
+     * @return string
+     */
+    public function getOperation(): string
+    {
+        return $this->operation;
+    }
+
+    /**
+     * Returns the SQL body.
+     *
+     * @return string|null
+     */
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+}

--- a/src/Operation/ViewOperation.php
+++ b/src/Operation/ViewOperation.php
@@ -26,8 +26,8 @@ class ViewOperation extends AbstractOperation
     /**
      * ViewOperation constructor.
      *
-     * @param string $view
-     * @param string $operation
+     * @param string      $view
+     * @param string      $operation
      * @param string|null $body
      */
     public function __construct(string $view, string $operation, string $body = null)

--- a/src/Statement/StatementBuilder.php
+++ b/src/Statement/StatementBuilder.php
@@ -2,17 +2,35 @@
 
 namespace Exo\Statement;
 
+use Exo\Operation\AbstractOperation;
 use Exo\Operation\TableOperation;
+use Exo\Operation\ViewOperation;
 
 abstract class StatementBuilder
 {
     /**
      * Builds SQL statements for an operation.
      *
+     * @param AbstractOperation $operation
+     * @return string
+     */
+    abstract public function build($operation): string;
+
+    /**
+     * Builds SQL statements for an operation.
+     *
      * @param TableOperation $operation
      * @return string
      */
-    abstract public function build(TableOperation $operation): string;
+    abstract public function buildTable(TableOperation $operation): string;
+
+    /**
+     * Builds SQL statements for an operation.
+     *
+     * @param ViewOperation $operation
+     * @return string
+     */
+    abstract public function buildView(ViewOperation $operation): string;
 
     /**
      * Builds an identifier.

--- a/src/ViewMigration.php
+++ b/src/ViewMigration.php
@@ -79,7 +79,7 @@ class ViewMigration
      */
     public function withBody(string $body): self
     {
-        if ($this->operation === ViewMigration::DROP) {
+        if ($this->operation === ViewOperation::DROP) {
             throw new \LogicException('Cannot set view body in a view drop migration.');
         }
 

--- a/src/ViewMigration.php
+++ b/src/ViewMigration.php
@@ -60,8 +60,8 @@ class ViewMigration
     /**
      * Migration constructor.
      *
-     * @param string $name
-     * @param string $operation
+     * @param string      $name
+     * @param string      $operation
      * @param string|null $body
      */
     private function __construct(string $name, string $operation, string $body = null)

--- a/src/ViewMigration.php
+++ b/src/ViewMigration.php
@@ -79,7 +79,7 @@ class ViewMigration
      */
     public function withBody(string $body): self
     {
-        if ($this->operation === TableOperation::DROP) {
+        if ($this->operation === ViewMigration::DROP) {
             throw new \LogicException('Cannot set view body in a view drop migration.');
         }
 

--- a/src/ViewMigration.php
+++ b/src/ViewMigration.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Exo;
+
+use Exo\Operation\ColumnOperation;
+use Exo\Operation\IndexOperation;
+use Exo\Operation\TableOperation;
+use Exo\Operation\ViewOperation;
+
+class ViewMigration
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $operation;
+
+    /**
+     * @var string|null
+     */
+    private $body = null;
+
+    /**
+     * Returns a new create view migration.
+     *
+     * @param string $name
+     * @return static
+     */
+    public static function create(string $name)
+    {
+        return new self($name, ViewOperation::CREATE);
+    }
+
+    /**
+     * Returns a new alter view migration.
+     *
+     * @param string $name
+     * @return static
+     */
+    public static function alter(string $name)
+    {
+        return new self($name, ViewOperation::ALTER);
+    }
+
+    /**
+     * Returns a new drop view migration.
+     *
+     * @param string $name
+     * @return static
+     */
+    public static function drop(string $name)
+    {
+        return new self($name, ViewOperation::DROP);
+    }
+
+    /**
+     * Migration constructor.
+     *
+     * @param string $name
+     * @param string $operation
+     * @param string|null $body
+     */
+    private function __construct(string $name, string $operation, string $body = null)
+    {
+        $this->name = $name;
+        $this->operation = $operation;
+        $this->body = $body;
+    }
+
+    /**
+     * Pushes a new add column operation.
+     *
+     * @param string $body
+     * @return ViewMigration
+     */
+    public function withBody(string $body): self
+    {
+        if ($this->operation === TableOperation::DROP) {
+            throw new \LogicException('Cannot set view body in a view drop migration.');
+        }
+
+        return new ViewMigration($this->name, $this->operation, $body);
+    }
+
+    /**
+     * Returns the table operation.
+     *
+     * @return ViewOperation
+     */
+    public function getOperation()
+    {
+        return new ViewOperation($this->name, $this->operation, $this->body);
+    }
+}

--- a/tests/Migrations/20200602_create_user_counts_view.php
+++ b/tests/Migrations/20200602_create_user_counts_view.php
@@ -1,0 +1,4 @@
+<?php
+
+return Exo\ViewMigration::create('user_counts')
+    ->withBody('select count(users.id) as user_count from test.users');

--- a/tests/Migrations/20200602_create_user_counts_view.php
+++ b/tests/Migrations/20200602_create_user_counts_view.php
@@ -1,4 +1,4 @@
 <?php
 
 return Exo\ViewMigration::create('user_counts')
-    ->withBody('select count(users.id) as user_count from test.users');
+    ->withBody('select count(distinct id) as user_count from test.users');

--- a/tests/Operation/ViewOperationTest.php
+++ b/tests/Operation/ViewOperationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Exo\Operation;
+
+class ViewOperationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testApplyAlterToCreate()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::CREATE, 'SELECT first_name FROM USERS');
+
+        $operation = $base->apply(new ViewOperation('user_view', ViewOperation::ALTER, 'SELECT first_name, last_name FROM USERS'));
+
+        $this->assertEquals('user_view', $operation->getView());
+        $this->assertEquals(ViewOperation::CREATE, $operation->getOperation());
+        $this->assertEquals('SELECT first_name, last_name FROM USERS', $operation->getBody());
+    }
+
+    public function testApplyDropToCreate()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::CREATE, 'SELECT first_name FROM USERS');
+
+        $operation = $base->apply(new ViewOperation('user_view', ViewOperation::DROP));
+
+        $this->assertNull($operation);
+    }
+
+    public function testApplyAlterToAlter()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::ALTER, 'SELECT first_name FROM USERS');
+
+        $operation = $base->apply(new ViewOperation('user_view', ViewOperation::ALTER, 'SELECT first_name, last_name FROM USERS'));
+
+        $this->assertEquals('user_view', $operation->getView());
+        $this->assertEquals(ViewOperation::ALTER, $operation->getOperation());
+        $this->assertEquals('SELECT first_name, last_name FROM USERS', $operation->getBody());
+    }
+
+    public function testApplyDropToAlter()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::ALTER, 'SELECT first_name FROM USERS');
+
+        $drop = new ViewOperation('user_view', ViewOperation::DROP);
+
+        $operation = $base->apply($drop);
+        $this->assertEquals($drop->getOperation(), $operation->getOperation());
+    }
+
+    public function testReverseCreate()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::CREATE, 'SELECT first_name FROM USERS');
+
+        $operation = $base->reverse();
+
+        $this->assertEquals('user_view', $operation->getView());
+        $this->assertEquals(ViewOperation::DROP, $operation->getOperation());
+    }
+
+    public function testReverseAlter()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::ALTER, 'SELECT first_name, last_name FROM USERS');
+
+        $create = new ViewOperation('user_view', ViewOperation::CREATE, 'SELECT first_name FROM USERS');
+
+        $operation = $base->reverse($create);
+
+        $this->assertEquals('user_view', $operation->getView());
+        $this->assertEquals(ViewOperation::ALTER, $operation->getOperation());
+        $this->assertEquals('SELECT first_name FROM USERS', $operation->getBody());
+    }
+
+    public function testReverseDrop()
+    {
+        $base = new ViewOperation('user_view', ViewOperation::DROP);
+
+        $create = new ViewOperation('user_view', ViewOperation::CREATE, 'SELECT first_name FROM USERS');
+
+        $operation = $base->reverse($create);
+
+        $this->assertEquals($create, $operation);
+    }
+}

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -5,13 +5,16 @@ namespace Exo\Statement;
 use Exo\Operation\ColumnOperation;
 use Exo\Operation\IndexOperation;
 use Exo\Operation\TableOperation;
+use Exo\Operation\ViewOperation;
 
 class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provider
+     * @param TableOperation|ViewOperation $operation
+     * @param string $sql
      */
-    public function testBuild(TableOperation $operation, string $sql)
+    public function testBuild($operation, string $sql)
     {
         $handler = new MysqlStatementBuilder();
         $this->assertEquals($sql, $handler->build($operation));
@@ -93,6 +96,18 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
             [
                 new TableOperation('users', TableOperation::DROP, [], []),
                 'DROP TABLE `users`;'
+            ],
+            [
+                new ViewOperation('user_counts', ViewOperation::CREATE, 'select count(users.id) as user_count from test.users'),
+                'CREATE OR REPLACE VIEW `user_counts` AS (select count(users.id) as user_count from test.users);'
+            ],
+            [
+                new ViewOperation('user_counts', ViewOperation::ALTER, 'select count(*) as user_count from test.users'),
+                'CREATE OR REPLACE VIEW `user_counts` AS (select count(*) as user_count from test.users);'
+            ],
+            [
+                new ViewOperation('user_counts', ViewOperation::DROP),
+                'DROP VIEW `user_counts`;'
             ]
         ];
     }

--- a/tests/Util/FinderTest.php
+++ b/tests/Util/FinderTest.php
@@ -8,11 +8,12 @@ class FinderTest extends \PHPUnit\Framework\TestCase
     {
         $finder = new Finder();
         $history = $finder->fromPath(__DIR__ . '/../Migrations');
-        $operations = $history->play('20190901_create_users', '20190912_create_posts');
+        $operations = $history->play('20190901_create_users', '20200602_create_user_counts_view');
 
-        $this->assertEquals(['20190901_create_users', '20190905_alter_users', '20190912_create_posts'], $history->getVersions());
+        $this->assertEquals(['20190901_create_users', '20190905_alter_users', '20190912_create_posts', '20200602_create_user_counts_view'], $history->getVersions());
         $this->assertEquals('users', $operations[0]->getTable());
         $this->assertEquals('users', $operations[1]->getTable());
         $this->assertEquals('posts', $operations[2]->getTable());
+        $this->assertEquals('user_counts', $operations[3]->getView());
     }
 }

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Exo;
+
+use Exo\Operation\ViewOperation;
+
+class ViewTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCreateView()
+    {
+        $operation = ViewMigration::create('user_counts')
+            ->withBody('SELECT COUNT(username) as usernames FROM USERS')
+            ->getOperation();
+
+        $this->assertEquals('user_counts', $operation->getView());
+        $this->assertEquals(ViewOperation::CREATE, $operation->getOperation());
+        $this->assertEquals('SELECT COUNT(username) as usernames FROM USERS', $operation->getBody());
+    }
+
+    public function testAlterView()
+    {
+        $operation = ViewMigration::alter('user_counts')
+            ->withBody('SELECT COUNT(username) as usernames, COUNT(DISTINCT username) as distinct_usernames FROM USERS')
+            ->getOperation();
+
+        $this->assertEquals('user_counts', $operation->getView());
+        $this->assertEquals(ViewOperation::ALTER, $operation->getOperation());
+        $this->assertEquals('SELECT COUNT(username) as usernames, COUNT(DISTINCT username) as distinct_usernames FROM USERS', $operation->getBody());
+    }
+
+    public function testDropView()
+    {
+        $operation = ViewMigration::drop('user_counts')
+            ->getOperation();
+
+        $this->assertEquals('user_counts', $operation->getView());
+        $this->assertEquals(ViewOperation::DROP, $operation->getOperation());
+        $this->assertNull($operation->getBody());
+    }
+
+    public function testPreventModifyBodyDuringDrop()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot set view body in a view drop migration.');
+
+        ViewMigration::drop('user_counts')
+            ->withBody('SELECT COUNT(username) as usernames FROM USERS');
+    }
+}


### PR DESCRIPTION
**Change Description:**
This PR implements changes which allow for views by tithely/exo migrations. (create|alter|drop)

The definition of ViewMigrations are much simpler than standard Migrations (tables) in terms of their classification, requiring only the name, operation, and SQL statement (if applicable) to manage the view; for this reason, and for clarity sake, I did not try to make Migrations work for views and opted for the new class.

**Changes made:**
- Create ViewMigration Class (Parallel to Migration)
- Create ViewOperation Class (Parallel to TableOperation)
- Update StatementHandler implementations to create the appropriate SQL based on class type, etc.
- Update History and Handlers to handle the classes by type.
- Add/update test cases to validate changes as needed.

**Example migration:**
```
<?php

return Exo\ViewMigration::create('user_counts')
    ->withBody('select count(distinct id) as user_count from test.users');


```

**Reviewer Notes**
Please review code for sanity checks, run tests, and put ViewMigrations through their paces.
Let me know if there is a preferred approach to this type of enhancement, I am happy to refactor if needed.