### PR TITLE
Add PHP 7.4 to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
-php: 7.3
+php:
+  - 7.3
+  - 7.4
 
 services: mysql
 


### PR DESCRIPTION
This PR adds PHP 7.4 to the TravisCI configuration file so that tests are run on that version.