### PR TITLE
[ENHANCEMENT] - Support missed migrations

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -100,7 +100,7 @@ class Handler
             $history = $this->history->clone($versions);
 
             $from = $target ? array_search($target, $versions) : 0;
-            $count = count($versions) - $from - 1;
+            $count = null;
         } else {
             // Determine range from current and target versions
             $history = $this->history;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -34,13 +34,19 @@ class Handler
     /**
      * Migrates from current to target version.
      *
-     * @param string|null $current
-     * @param string|null $target
-     * @param bool        $reduce
+     * If $current is a string, all history since the specified
+     * version will be executed. If $current is an array, any
+     * versions not present will be executed. If $target is a
+     * string, history up to and including the specified version
+     * will be executed.
+     *
+     * @param string[]|string|null $current
+     * @param string|null          $target
+     * @param bool                 $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function migrate(?string $current, ?string $target, bool $reduce): array
+    public function migrate($current, ?string $target, bool $reduce): array
     {
         $versions = $this->history->getVersions();
         $version = null;
@@ -66,13 +72,16 @@ class Handler
     /**
      * Performs a rollback from current to target version.
      *
-     * @param string      $current
-     * @param string|null $target
-     * @param bool        $reduce
+     * If $current is an array, any versions not present will
+     * not be considered by the rollback.
+     *
+     * @param string[]|string $current
+     * @param string|null     $target
+     * @param bool            $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function rollback(string $current, ?string $target, bool $reduce): array
+    public function rollback($current, ?string $target, bool $reduce): array
     {
         $versions = $this->history->getVersions();
         $from = $target ? array_search($target, $versions) : 0;
@@ -93,12 +102,13 @@ class Handler
 
     /**
      * @param AbstractOperation[] $operations
-     * @param array $versions
-     * @param bool $reduce
+     * @param array               $versions
+     * @param bool                $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    private function processOperations(array $operations, array $versions, bool $reduce): array {
+    private function processOperations(array $operations, array $versions, bool $reduce): array
+    {
         $results = [];
 
         foreach ($operations as $offset => $operation) {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -51,12 +51,21 @@ class Handler
         $versions = $this->history->getVersions();
         $version = null;
 
-        while ($version !== $current && !empty($versions)) {
-            $version = array_shift($versions);
-        }
+        if (is_array($current)) {
+            // Determine versions excluding all executed
+            $versions = array_values(array_diff($versions, $current));
+            $history = $this->history->clone($versions);
+        } else {
+            // Determine versions since last executed
+            while ($version !== $current && !empty($versions)) {
+                $version = array_shift($versions);
+            }
 
-        if (!is_null($current) && is_null($version)) {
-            throw new \InvalidArgumentException('Current version is invalid.');
+            if (!is_null($current) && is_null($version)) {
+                throw new \InvalidArgumentException('Current version is invalid.');
+            }
+
+            $history = $this->history;
         }
 
         // Determine range of versions to play
@@ -64,7 +73,7 @@ class Handler
         $to = $target ?? end($versions);
 
         // Execute operations
-        $operations = $this->history->play($from, $to, $reduce);
+        $operations = $history->play($from, $to, $reduce);
 
         return $this->processOperations($operations, $versions, $reduce);
     }

--- a/src/History.php
+++ b/src/History.php
@@ -10,7 +10,7 @@ use Exo\Operation\ViewOperation;
 class History
 {
     /**
-     * @var array
+     * @var Migration[]|ViewMigration[]
      */
     private $migrations = [];
 
@@ -39,6 +39,27 @@ class History
     }
 
     /**
+     * Returns the entity name for an operation.
+     *
+     * @param AbstractOperation $operation
+     * @return string
+     * @throws UnsupportedOperationException
+     */
+    private static function getEntityName(AbstractOperation $operation)
+    {
+        $operationClass = get_class($operation);
+
+        switch ($operationClass) {
+            case TableOperation::class:
+                return $operation->getTable();
+            case ViewOperation::class:
+                return $operation->getView();
+            default:
+                throw new UnsupportedOperationException($operationClass);
+        }
+    }
+
+    /**
      * Adds a migration to the history.
      *
      * @param string                  $version
@@ -47,6 +68,26 @@ class History
     public function add(string $version, $migrationOrView)
     {
         $this->migrations[$version] = $migrationOrView;
+    }
+
+    /**
+     * Clones the history, optionally including only the
+     * specified versions.
+     *
+     * @param array|null $versions
+     * @return History
+     */
+    public function clone(array $versions = null)
+    {
+        $history = new History();
+
+        foreach ($this->migrations as $version => $migration) {
+            if (is_null($versions) || in_array($version, $versions)) {
+                $history->add($version, $migration);
+            }
+        }
+
+        return $history;
     }
 
     /**
@@ -137,27 +178,6 @@ class History
         }
 
         return $operations;
-    }
-
-    /**
-     * Returns the entity name for an operation.
-     *
-     * @param AbstractOperation $operation
-     * @return string
-     * @throws UnsupportedOperationException
-     */
-    private static function getEntityName(AbstractOperation $operation)
-    {
-        $operationClass = get_class($operation);
-
-        switch ($operationClass) {
-            case TableOperation::class:
-                return $operation->getTable();
-            case ViewOperation::class:
-                return $operation->getView();
-            default:
-                throw new UnsupportedOperationException($operationClass);
-        }
     }
 
     /**

--- a/src/History.php
+++ b/src/History.php
@@ -41,7 +41,7 @@ class History
     /**
      * Adds a migration to the history.
      *
-     * @param string         $version
+     * @param string                  $version
      * @param Migration|ViewMigration $migrationOrView
      */
     public function add(string $version, $migrationOrView)
@@ -58,6 +58,7 @@ class History
      * @param string $to
      * @param bool   $reduce
      * @return TableOperation[]
+     * @throws UnsupportedOperationException
      */
     public function play(string $from, string $to, bool $reduce = false)
     {
@@ -138,17 +139,22 @@ class History
         return $operations;
     }
 
-    private static function getEntityName(AbstractOperation $operation) {
+    /**
+     * Returns the entity name for an operation.
+     *
+     * @param AbstractOperation $operation
+     * @return string
+     * @throws UnsupportedOperationException
+     */
+    private static function getEntityName(AbstractOperation $operation)
+    {
         $operationClass = get_class($operation);
 
-        switch($operationClass) {
-
+        switch ($operationClass) {
             case TableOperation::class:
                 return $operation->getTable();
-                break;
             case ViewOperation::class:
                 return $operation->getView();
-                break;
             default:
                 throw new UnsupportedOperationException($operationClass);
         }

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -65,6 +65,17 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(TableOperation::DROP, $operations[1]->getOperation());
     }
 
+    public function testClone()
+    {
+        $history = $this->getHistory();
+
+        $cloned = $history->clone();
+        $this->assertEquals(['1', '2', '3'], $cloned->getVersions());
+
+        $cloned = $history->clone(['1', '3']);
+        $this->assertEquals(['1', '3'], $cloned->getVersions());
+    }
+
     private function getHistory()
     {
         $history = new History();

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -74,6 +74,22 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($results[1]->isSuccess());
     }
 
+    public function testMissedMigration()
+    {
+        $handler = $this->getHandler();
+        $handler->migrate(null, '1', false);
+        $handler->migrate('2', '3', false);
+
+        $results = $handler->migrate(['1', '3'], null, false);
+        $this->assertCount(3, $results);
+        $this->assertEquals('2', $results[0]->getVersion());
+        $this->assertTrue($results[0]->isSuccess());
+        $this->assertEquals('4', $results[1]->getVersion());
+        $this->assertTrue($results[1]->isSuccess());
+        $this->assertEquals('5', $results[2]->getVersion());
+        $this->assertTrue($results[2]->isSuccess());
+    }
+
     public function testFailingMigration()
     {
         $handler = $this->getHandler();

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -74,7 +74,7 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($results[1]->isSuccess());
     }
 
-    public function testMissedMigration()
+    public function testMigrationWithMissed()
     {
         $handler = $this->getHandler();
         $handler->migrate(null, '1', false);
@@ -82,12 +82,12 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
 
         $results = $handler->migrate(['1', '3'], null, false);
         $this->assertCount(3, $results);
-        $this->assertEquals('2', $results[0]->getVersion());
         $this->assertTrue($results[0]->isSuccess());
-        $this->assertEquals('4', $results[1]->getVersion());
+        $this->assertEquals('2', $results[0]->getVersion());
         $this->assertTrue($results[1]->isSuccess());
-        $this->assertEquals('5', $results[2]->getVersion());
+        $this->assertEquals('4', $results[1]->getVersion());
         $this->assertTrue($results[2]->isSuccess());
+        $this->assertEquals('5', $results[2]->getVersion());
     }
 
     public function testFailingMigration()
@@ -111,6 +111,22 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $results);
         $this->assertTrue($results[0]->isSuccess());
         $this->assertEquals('3', $results[0]->getVersion());
+    }
+
+    public function testMissedRollback()
+    {
+        $handler = $this->getHandler();
+        $handler->migrate(null, '1', false);
+        $handler->migrate('2', '5', false);
+
+        $results = $handler->rollback(['1', '3', '4', '5'], '1', false);
+        $this->assertCount(3, $results);
+        $this->assertTrue($results[0]->isSuccess());
+        $this->assertEquals('5', $results[0]->getVersion());
+        $this->assertTrue($results[1]->isSuccess());
+        $this->assertEquals('4', $results[1]->getVersion());
+        $this->assertTrue($results[2]->isSuccess());
+        $this->assertEquals('3', $results[2]->getVersion());
     }
 
     public function testFailingRollback()

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -113,7 +113,7 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('3', $results[0]->getVersion());
     }
 
-    public function testMissedRollback()
+    public function testRollbackWithMissed()
     {
         $handler = $this->getHandler();
         $handler->migrate(null, '1', false);

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -131,11 +131,11 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         );
 
         $history->add('4', ViewMigration::create('user_counts')
-            ->withBody('select count(*) as user_count from test.users')
+            ->withBody('select count(*) as user_count from users')
         );
 
         $history->add('5', ViewMigration::alter('user_counts')
-            ->withBody('select count(distinct id) as user_count from test.users')
+            ->withBody('select count(distinct id) as user_count from users')
         );
 
         return new Handler($this->pdo, $history);


### PR DESCRIPTION
This PR extends the migration handler API to accept a list of executed migration versions in place of a single 'current' version parameter when performing migration or rollback.

```php
// Executes all migrations except for '1' and '3'
$handler->migrate(['1', '3'], null, false);
```

**Issues**

In its current state, exo supports migration and rollback over contiguous versions of a migration history. For migration this means all versions after a 'current' version, up to and including a 'target' version, are executed. For rollback this means all versions from a 'current' version, back to but excluding a 'target' version, are executed.

This is not a problem if the migration history remains append-only from one application version to the next. It is common however that several feature branches exist in a project at any one time and versions may be missed depending on the order in which the branches are merged and migrated.

To illustrate this with an example:

1. Feature branch **feature-a** introduces migration version **20200610_add_users**
2. Feature branch **feature-b** introduces migration version **20200611_add_meta**
3. Feature branch **feature-b** is merged into **master** and migrations are executed
4. Feature branch **feature-a** is merged into **master** and migrations are executed
5. Since migration version **20200611_add_meta** is the current version, migration version **20200610_add_users** is never run

**Solution**

Supplying an array of executed versions provides the handler with context required to determine which migration versions have not been executed, regardless of their position within the history. The updated code works by creating a new history by diffing all available versions with those that have been executed. During migration, the first version which has not been executed, up to and including the target version, are executed. During rollback, only executed versions are reversed and executed.

**Usage**

Both `Handler::migrate()` and `Handler::rollback()` are backwards compatible and support provision of a single 'current' version. Applications opting to use the updated API need to store a list of executed migration versions instead of the 'last executed' migration version. This list should be updated after rollback to exclude the reversed migration versions.

```php
// Executes all available migrations that have not been executed
$versions = $storage->get('migrations');
$results = $handler->migrate($versions, null, false);

foreach ($results as $result) {
    $versions[] = $result->getVersion();
}

$storage->set('migrations', $versions);

// Reverts all executed migrations after '3'
$results = $handler->rollback($versions, '3', false);

foreach ($results as $result) {
    $index = array_search($versions, $result->getVersion());

    if ($index !== false) {
        unset($versions[$index]);
    }
}

$storage->set('migrations', array_values($versions));
```