### PR TITLE
[ENHANCEMENT] - Finalize Handler API

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -61,23 +61,19 @@ class Handler
     /**
      * Performs a rollback to target version.
      *
-     * @param string[]    $executed
-     * @param string|null $target
-     * @param bool        $reduce
+     * @param string[] $executed
+     * @param string   $target
+     * @param bool     $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function rollback(array $executed, ?string $target, bool $reduce): array
+    public function rollback(array $executed, string $target, bool $reduce): array
     {
         $history = $this->history->clone($executed);
-        $from = 0;
+        $from = array_search($target, $executed);
 
-        if ($target) {
-            $from = array_search($target, $executed);
-
-            if ($from === false) {
-                throw new \InvalidArgumentException(sprintf('Unknown target version "%s".', $target));
-            }
+        if ($from === false) {
+            throw new \InvalidArgumentException(sprintf('Unknown target version "%s".', $target));
         }
 
         $versions = array_slice(

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -61,19 +61,23 @@ class Handler
     /**
      * Performs a rollback to target version.
      *
-     * @param string[] $executed
-     * @param string   $target
-     * @param bool     $reduce
+     * @param string[]    $executed
+     * @param string|null $target
+     * @param bool        $reduce
      * @return HandlerResult[]
      * @throws Operation\UnsupportedOperationException
      */
-    public function rollback(array $executed, string $target, bool $reduce): array
+    public function rollback(array $executed, ?string $target, bool $reduce): array
     {
         $history = $this->history->clone($executed);
-        $from = array_search($target, $executed);
+        $from = -1;
 
-        if ($from === false) {
-            throw new \InvalidArgumentException(sprintf('Unknown target version "%s".', $target));
+        if ($target) {
+            $from = array_search($target, $executed);
+
+            if ($from === false) {
+                throw new \InvalidArgumentException(sprintf('Unknown target version "%s".', $target));
+            }
         }
 
         $versions = array_slice(

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -138,6 +138,15 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('3', $results[3]->getVersion());
     }
 
+    public function testRollbackWithoutTarget()
+    {
+        $handler = $this->getHandler();
+        $handler->migrate([], '3', false);
+        $results = $handler->rollback(['1', '2', '3'], null, false);
+
+        $this->assertCount(3, $results);
+    }
+
     public function testFailingRollback()
     {
         $handler = $this->getHandler();

--- a/tests/MysqlHandlerTest.php
+++ b/tests/MysqlHandlerTest.php
@@ -37,7 +37,7 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testFullMigration()
     {
         $handler = $this->getHandler();
-        $results = $handler->migrate(null, null, false);
+        $results = $handler->migrate([], null, false);
 
         $this->assertCount(6, $results);
         $this->assertTrue($results[0]->isSuccess());
@@ -57,7 +57,7 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testFullMigrationReduced()
     {
         $handler = $this->getHandler();
-        $results = $handler->migrate(null, null, true);
+        $results = $handler->migrate([], null, true);
 
         $this->assertCount(4, $results);
         $this->assertTrue($results[0]->isSuccess());
@@ -72,7 +72,7 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testPartialMigration()
     {
         $handler = $this->getHandler();
-        $results = $handler->migrate(null, '2', false);
+        $results = $handler->migrate([], '2', false);
 
         $this->assertCount(2, $results);
         $this->assertTrue($results[0]->isSuccess());
@@ -82,8 +82,8 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testMigrationWithMissed()
     {
         $handler = $this->getHandler();
-        $handler->migrate(null, '1', false);
-        $handler->migrate('2', '3', false);
+        $handler->migrate([], '1', false);
+        $handler->migrate(['1', '2'], '3', false);
 
         $results = $handler->migrate(['1', '3'], null, false);
         $this->assertCount(4, $results);
@@ -100,8 +100,8 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testFailingMigration()
     {
         $handler = $this->getHandler();
-        $handler->migrate(null, null, true);
-        $results = $handler->migrate('1', '2', false);
+        $handler->migrate([], null, true);
+        $results = $handler->migrate(['1'], '2', false);
 
         $this->assertCount(1, $results);
         $this->assertFalse($results[0]->isSuccess());
@@ -112,8 +112,8 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testRollback()
     {
         $handler = $this->getHandler();
-        $handler->migrate(null, null, false);
-        $results = $handler->rollback('3', '2', false);
+        $handler->migrate([], null, false);
+        $results = $handler->rollback(['1', '2', '3'], '2', false);
 
         $this->assertCount(1, $results);
         $this->assertTrue($results[0]->isSuccess());
@@ -123,8 +123,8 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testRollbackWithMissed()
     {
         $handler = $this->getHandler();
-        $handler->migrate(null, '1', false);
-        $handler->migrate('2', '6', false);
+        $handler->migrate([], '1', false);
+        $handler->migrate(['1', '2'], '6', false);
 
         $results = $handler->rollback(['1', '3', '4', '5', '6'], '1', false);
         $this->assertCount(4, $results);
@@ -141,8 +141,8 @@ class MysqlHandlerTest extends \PHPUnit\Framework\TestCase
     public function testFailingRollback()
     {
         $handler = $this->getHandler();
-        $handler->migrate(null, '2', false);
-        $results = $handler->rollback('3', '1', false);
+        $handler->migrate([], '2', false);
+        $results = $handler->rollback(['1', '2', '3'], '1', false);
 
         $this->assertCount(1, $results);
         $this->assertFalse($results[0]->isSuccess());


### PR DESCRIPTION
This PR finalizes the API for the `Handler` class such that both the `migrate()` and `rollback()` methods require an array of executed versions as the first parameter. All versions are now reverted if a `$target` of `null` is provided for rollback.

**Rationale**
Previously it was possible to pass a single version string to be interpreted as the last effective version applied to the database. Support was later [introduced](https://github.com/tithely/exo/pull/11) for an array of executed versions to facilitate missed versions (e.g. due to feature branching).

With the ability to specify every executed version, support for a single version string is now redundant, requires more code and leads to a more complex API.

The previous behavior for a rollback with a null target was to revert all but the first migration version, however it was not possible to revert the first version. As a result, `null` is now interpreted as the version prior to any migrations being executed.

**Upgrading**

This branch introduces breaking changes and will therefore be released in a new major version. Projects using the original API will need to update call sites with an array of versions up to and including the most recently executed version number. The second argument to `Handler::rollback` must be provided unless all migrations are to be reverted.

```php
// Unsupported usage
$handler->migrate('3', '6', false);
$handler->rollback('6', '4', false);

// Updated usage
$handler->migrate(['1', '2', '3'], '6',  false);
$handler->rollback(['1', '2', '3', '4', '5', '6'], '4', false);
```

It is recommended that a complete list of execute versions is stored between migration/rollback. This will ensure projects do not suffer from missed migrations due to the order in which feature branches responsible for new migrations are merged.