### PR TITLE
Move positioning of AFTER and DEFAULT in queries

### DIFF
--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -335,12 +335,12 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= ' FIRST';
         }
 
-        if ($options['after'] ?? null) {
-            $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
-        }
-
         if (array_key_exists('default', $options)) {
             $definition .= sprintf(' DEFAULT %s', $this->buildDefaultValue($options['default']));
+        }
+
+        if ($options['after'] ?? null) {
+            $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
         }
 
         if ($options['update'] ?? false) {

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -87,14 +87,14 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 new TableOperation('users', TableOperation::ALTER, [
-                    new ColumnOperation('meta', ColumnOperation::ADD, ['type' => 'json', 'after' => 'password']),
+                    new ColumnOperation('meta', ColumnOperation::ADD, ['type' => 'json', 'default' => '["meta"]', 'after' => 'password']),
                     new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
                     new ColumnOperation('created_at', ColumnOperation::DROP, [])
                 ], [
                     new IndexOperation('meta', IndexOperation::ADD, ['meta'], []),
                     new IndexOperation('username', IndexOperation::DROP, [], [])
                 ]),
-                'ALTER TABLE `users` ADD COLUMN `meta` JSON AFTER `password`, MODIFY COLUMN `username` VARCHAR(255), ' .
+                'ALTER TABLE `users` ADD COLUMN `meta` JSON DEFAULT \'["meta"]\' AFTER `password`, MODIFY COLUMN `username` VARCHAR(255), ' .
                 'DROP COLUMN `created_at`, ADD INDEX `meta` (`meta`), DROP INDEX `username`;'
             ],
             [


### PR DESCRIPTION
This PR changes the order of `DEFAULT` inside of queries when used in conjunction with `AFTER` The old order was causing errors.

Tests have been updated to validate the changes.