### PR TITLE
[HOTFIX] Fix creation of unique indexes

### DIFF
--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -48,7 +48,7 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                 '`password` VARCHAR(255), `gender` ENUM(\'male\',\'female\') DEFAULT \'male\', ' .
                 '`tinytext` TINYTEXT, `summary` TEXT, `description` MEDIUMTEXT, `novel` LONGTEXT, ' .
                 '`archived` SMALLINT(1) DEFAULT 1, `status` VARCHAR(255) DEFAULT \'draft\', ' .
-                '`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX `username` (`username`) UNIQUE);'
+                '`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, UNIQUE INDEX `username` (`username`));'
             ],
             [
                 new TableOperation('users', TableOperation::CREATE, [
@@ -91,11 +91,11 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
                     new ColumnOperation('created_at', ColumnOperation::DROP, [])
                 ], [
-                    new IndexOperation('meta', IndexOperation::ADD, ['meta'], []),
+                    new IndexOperation('meta', IndexOperation::ADD, ['meta'], ['unique' => true]),
                     new IndexOperation('username', IndexOperation::DROP, [], [])
                 ]),
                 'ALTER TABLE `users` ADD COLUMN `meta` JSON DEFAULT \'["meta"]\' AFTER `password`, MODIFY COLUMN `username` VARCHAR(255), ' .
-                'DROP COLUMN `created_at`, ADD INDEX `meta` (`meta`), DROP INDEX `username`;'
+                'DROP COLUMN `created_at`, ADD UNIQUE INDEX `meta` (`meta`), DROP INDEX `username`;'
             ],
             [
                 new TableOperation('users', TableOperation::DROP, [], []),


### PR DESCRIPTION
This pull request fixes an error that occurs when creating unique indexes for both `CREATE TABLE` and `ALTER TABLE` statements..

Take this migration as an example:

```php
return \Exo\Migration::create('registration_discounts')
    ->addColumn('registration_id', ['type' => 'uuid'])
    ->addColumn('discount_id', ['type' => 'uuid'])
    ->addIndex('registration_id', ['registration_id'], ['unique' => true]);
```

The previous handling would use the following query to create the index, resulting in an error:

```sql
INDEX `registration_id` (`registration_id`) UNIQUE
```

```
private $errorInfo => array(3) {
    [0] => string(5) "42000"
    [1] => int(1064)
    [2] => string(153) "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'UNIQUE)' at line 1"
}
```

With my changes, the following query is used as per [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/create-table.html):

```sql
UNIQUE INDEX `registration_id` (`registration_id`)
```