### PR TITLE
[HOTFIX] Syntax ordering for AFTER

### DIFF
--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -349,12 +349,12 @@ class MysqlStatementBuilder extends StatementBuilder
             $definition .= sprintf(' DEFAULT %s', $this->buildDefaultValue($options['default']));
         }
 
-        if ($options['after'] ?? null) {
-            $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
-        }
-
         if ($options['update'] ?? false) {
             $definition .= sprintf(' ON UPDATE %s', $options['update']);
+        }
+
+        if ($options['after'] ?? null) {
+            $definition .= sprintf(' AFTER %s', $this->buildIdentifier($options['after']));
         }
 
         return $definition;

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -88,13 +88,16 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
             [
                 new TableOperation('users', TableOperation::ALTER, [
                     new ColumnOperation('meta', ColumnOperation::ADD, ['type' => 'json', 'default' => '["meta"]', 'after' => 'password']),
+                    new ColumnOperation('date', ColumnOperation::ADD, ['type' => 'timestamp', 'update' => 'CURRENT_TIMESTAMP', 'after' => 'meta']),
                     new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
                     new ColumnOperation('created_at', ColumnOperation::DROP, [])
                 ], [
                     new IndexOperation('meta', IndexOperation::ADD, ['meta'], ['unique' => true]),
                     new IndexOperation('username', IndexOperation::DROP, [], [])
                 ]),
-                'ALTER TABLE `users` ADD COLUMN `meta` JSON DEFAULT \'["meta"]\' AFTER `password`, MODIFY COLUMN `username` VARCHAR(255), ' .
+                'ALTER TABLE `users` ADD COLUMN `meta` JSON DEFAULT \'["meta"]\' AFTER `password`, ' .
+                'ADD COLUMN `date` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `meta`, ' .
+                'MODIFY COLUMN `username` VARCHAR(255), ' .
                 'DROP COLUMN `created_at`, ADD UNIQUE INDEX `meta` (`meta`), DROP INDEX `username`;'
             ],
             [


### PR DESCRIPTION
This pull request fixes the ordering of `AFTER` when used in conjunction with `ON UPDATE`.

Take this example:

```php
return \Exo\Migration::alter('events')
    ->addColumn('updated_at', ['type' => 'timestamp', 'update' => 'CURRENT_TIMESTAMP', 'after' => 'created_at']);
```

Prior to this fix, this was the result:

```sql
ADD COLUMN `updated_at` TIMESTAMP AFTER `created_at` ON UPDATE CURRENT_TIMESTAMP
```

Now, the syntax outputs like this:

```sql
ADD COLUMN `updated_at` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`
```