### PR TITLE
[ENHANCEMENT] Add support for the READS SQL DATA property for custom function migrations.

### DIFF
--- a/src/FunctionMigration.php
+++ b/src/FunctionMigration.php
@@ -133,7 +133,7 @@ final class FunctionMigration
     }
 
     /**
-     * Sets determinism for the function.
+     * Sets the reads sql data property of the function.
      *
      * @param bool $readsSqlData
      * @return $this

--- a/src/FunctionMigration.php
+++ b/src/FunctionMigration.php
@@ -36,6 +36,11 @@ final class FunctionMigration
     private $deterministic;
 
     /**
+     * @var bool
+     */
+    private $readsSqlData;
+
+    /**
      * @var ParameterOperation[]
      */
     private $parameterOperations;
@@ -85,6 +90,7 @@ final class FunctionMigration
      * @param string $operation
      * @param ReturnTypeOperation $returnType
      * @param bool $deterministic
+     * @param bool $readsSqlData
      * @param array $parameterOperations
      * @param array $variableOperations
      * @param string|null $body
@@ -94,6 +100,7 @@ final class FunctionMigration
         string $operation,
         ReturnTypeOperation $returnType = null,
         bool $deterministic = false,
+        bool $readsSqlData = false,
         array $parameterOperations = [],
         array $variableOperations = [],
         string $body = null
@@ -102,13 +109,14 @@ final class FunctionMigration
         $this->operation = $operation;
         $this->returnType = $returnType;
         $this->deterministic = $deterministic;
+        $this->readsSqlData = $readsSqlData;
         $this->parameterOperations = $parameterOperations;
         $this->variableOperations = $variableOperations;
         $this->body = $body;
     }
 
     /**
-     * Pushes a new add parameter operation.
+     * Sets determinism for the function.
      *
      * @param bool $deterministic
      * @return $this
@@ -120,6 +128,23 @@ final class FunctionMigration
         }
 
         $this->deterministic = $deterministic;
+
+        return $this;
+    }
+
+    /**
+     * Sets determinism for the function.
+     *
+     * @param bool $readsSqlData
+     * @return $this
+     */
+    public function readsSqlData(bool $readsSqlData): FunctionMigration
+    {
+        if ($this->operation === FunctionOperation::DROP) {
+            throw new LogicException('Cannot set readsSqlData property in a drop migration.');
+        }
+
+        $this->readsSqlData = $readsSqlData;
 
         return $this;
     }
@@ -224,6 +249,7 @@ final class FunctionMigration
             $this->operation,
             $this->returnType,
             $this->deterministic,
+            $this->readsSqlData,
             $this->parameterOperations,
             $this->variableOperations,
             $this->body

--- a/src/Operation/FunctionOperation.php
+++ b/src/Operation/FunctionOperation.php
@@ -26,6 +26,11 @@ class FunctionOperation extends AbstractOperation
     private $deterministic;
 
     /**
+     * @var bool
+     */
+    private $readsSqlData;
+
+    /**
      * @var ParameterOperation[]
      */
     private $parameterOperations;
@@ -47,6 +52,7 @@ class FunctionOperation extends AbstractOperation
      * @param string $operation
      * @param ReturnTypeOperation|null $returnType
      * @param bool $deterministic
+     * @param bool $readsSqlData
      * @param array $parameterOperations
      * @param array $variableOperations
      * @param string|null $body
@@ -56,6 +62,7 @@ class FunctionOperation extends AbstractOperation
         string $operation,
         ReturnTypeOperation $returnType = null,
         bool $deterministic = false,
+        bool $readsSqlData = false,
         array $parameterOperations = [],
         array $variableOperations = [],
         string $body = null
@@ -64,6 +71,7 @@ class FunctionOperation extends AbstractOperation
         $this->operation = $operation;
         $this->returnType = $returnType ?? new ReturnTypeOperation('string', ReturnTypeOperation::ADD);
         $this->deterministic = $deterministic;
+        $this->readsSqlData = $readsSqlData;
         $this->parameterOperations = $parameterOperations;
         $this->variableOperations = $variableOperations;
         $this->body = $body;
@@ -145,6 +153,16 @@ class FunctionOperation extends AbstractOperation
     public function getDeterministic(): bool
     {
         return $this->deterministic;
+    }
+
+    /**
+     * Returns the readsSqlData flag.
+     *
+     * @return bool
+     */
+    public function getReadsSqlData(): bool
+    {
+        return $this->readsSqlData;
     }
 
     /**

--- a/src/Statement/MysqlStatementBuilder.php
+++ b/src/Statement/MysqlStatementBuilder.php
@@ -24,6 +24,7 @@ class MysqlStatementBuilder extends StatementBuilder
     )
     RETURNS %s
     %s
+    %s
     BEGIN
         %s
     
@@ -35,6 +36,7 @@ class MysqlStatementBuilder extends StatementBuilder
         %s
     )
     RETURNS %s
+    %s
     %s
     BEGIN
         %s
@@ -223,6 +225,10 @@ class MysqlStatementBuilder extends StatementBuilder
             ? 'DETERMINISTIC'
             : 'NOT DETERMINISTIC';
 
+        $readsSqlData = ($operation->getReadsSqlData())
+            ? 'READS SQL DATA'
+            : '';
+
         $variables = array_map(function(VariableOperation $variableOperation) {
             return sprintf(
                 'DECLARE %s %s;',
@@ -238,7 +244,8 @@ class MysqlStatementBuilder extends StatementBuilder
                     $this->buildIdentifier($operation->getName()), // NAME (for create)
                     implode(',', $parameters), // PARAMETERS
                     $returnType, // RETURN TYPE
-                    $determinism, // [NOT] DETERMINISTIC
+                    $determinism, // 'DETERMINISTIC' | 'NOT DETERMINISTIC'
+                    $readsSqlData, // 'READS SQL DATA' | ''
                     implode('', $variables), // VARIABLES
                     $operation->getBody() // BODY
                 );
@@ -249,7 +256,8 @@ class MysqlStatementBuilder extends StatementBuilder
                     $this->buildIdentifier($operation->getName()), // NAME (for create)
                     implode(',', $parameters), // PARAMETERS
                     $returnType, // RETURN TYPE
-                    $determinism, // [NOT] DETERMINISTIC
+                    $determinism, // 'DETERMINISTIC' | 'NOT DETERMINISTIC'
+                    $readsSqlData, // 'READS SQL DATA' | ''
                     implode('', $variables), // VARIABLES
                     $operation->getBody() // BODY
                 );

--- a/tests/Migrations/20200604_create_user_level_function.php
+++ b/tests/Migrations/20200604_create_user_level_function.php
@@ -3,6 +3,7 @@
 return Exo\FunctionMigration::create('user_level')
     ->withReturnType('integer')
     ->addParameter('inputValue', ['type' => 'integer'])
-    ->isDeterministic(false)
+    ->isDeterministic(true)
+    ->readsSqlData(false)
     ->addVariable('suffixValue', ['length' => '20'])
     ->withBody('RETURN CONCAT(CAST(inputValue AS CHAR(25), suffixValue);');

--- a/tests/Operation/FunctionOperationTest.php
+++ b/tests/Operation/FunctionOperationTest.php
@@ -32,6 +32,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $operation = new FunctionOperation('customer_level', FunctionOperation::CREATE,
             new ReturnTypeOperation('string', ReturnTypeOperation::ADD),
             true,
+            false,
             [
                 new ParameterOperation('arg1', ParameterOperation::ADD),
                 new ParameterOperation('arg2', ParameterOperation::ADD, ['type' => 'integer']),
@@ -48,6 +49,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([], $operation->getReturnType()->getOptions());
 
         $this->assertTrue($operation->getDeterministic());
+        $this->assertFalse($operation->getReadsSqlData());
 
         $this->assertCount(3, $operation->getParameterOperations());
 
@@ -77,6 +79,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $base = new FunctionOperation('customer_level', FunctionOperation::CREATE,
             new ReturnTypeOperation('string', ReturnTypeOperation::ADD),
             true,
+            false,
             [
                 new ParameterOperation('arg1', ParameterOperation::ADD),
                 new ParameterOperation('arg2', ParameterOperation::ADD, ['type' => 'integer']),
@@ -89,6 +92,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $new = new FunctionOperation('customer_level', FunctionOperation::REPLACE,
             new ReturnTypeOperation('integer', ReturnTypeOperation::ADD),
             false,
+            true,
             [],
             [],
             self::BODY_TWO
@@ -103,6 +107,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([], $operation->getReturnType()->getOptions());
 
         $this->assertFalse($operation->getDeterministic());
+        $this->assertTrue($operation->getReadsSqlData());
 
         $this->assertCount(0, $operation->getParameterOperations());
 
@@ -116,6 +121,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
         $base = new FunctionOperation('any_name', FunctionOperation::REPLACE,
             new ReturnTypeOperation('string', ReturnTypeOperation::ADD),
             true,
+            false,
             [],
             [],
             self::BODY_ONE
@@ -147,6 +153,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
             FunctionOperation::REPLACE,
             new ReturnTypeOperation('integer', ReturnTypeOperation::ADD),
             false,
+            true,
             [
                 new ParameterOperation('id', ParameterOperation::ADD, []),
                 new ParameterOperation('email', ParameterOperation::ADD, ['type' => 'string', 'length' => 255]),
@@ -164,6 +171,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
             FunctionOperation::REPLACE,
             new ReturnTypeOperation('string', ReturnTypeOperation::ADD),
             true,
+            false,
             [
                 new ParameterOperation('id', ParameterOperation::ADD, ['type' => 'uuid']),
                 new ParameterOperation('username', ParameterOperation::ADD, ['type' => 'string', 'length' => 64])
@@ -205,6 +213,7 @@ class FunctionOperationTest extends \PHPUnit\Framework\TestCase
             FunctionOperation::REPLACE,
             new ReturnTypeOperation('integer', ReturnTypeOperation::ADD),
             false,
+            true,
             [
                 new ParameterOperation('id', ParameterOperation::ADD, []),
                 new ParameterOperation('email', ParameterOperation::ADD, ['type' => 'string', 'length' => 255, 'first' => true]),

--- a/tests/Statement/MysqlStatementBuilderTest.php
+++ b/tests/Statement/MysqlStatementBuilderTest.php
@@ -122,6 +122,7 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     FunctionOperation::CREATE,
                     new ReturnTypeOperation('string', ReturnTypeOperation::ADD, ['length' => 20]),
                     true,
+                    false,
                     [
                         new ParameterOperation('inputValue1', ParameterOperation::ADD, ['length' => 32]),
                         new ParameterOperation('inputValue2', ParameterOperation::ADD, ['length' => 32])
@@ -138,6 +139,7 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     'inputValue1 VARCHAR(32),inputValue2 VARCHAR(32)',
                     'VARCHAR(20)',
                     'DETERMINISTIC',
+                    '',
                     'DECLARE internalVarName1 INTEGER;DECLARE internalVarName2 INTEGER;',
                     'RETURN \'foo\';'
                 )
@@ -147,6 +149,7 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     'user_defined_function',
                     FunctionOperation::REPLACE,
                     new ReturnTypeOperation('string', ReturnTypeOperation::ADD, ['length' => 20]),
+                    false,
                     true,
                     [new ParameterOperation('anotherInputValue', ParameterOperation::ADD, ['length' => 32])],
                     [new VariableOperation('anotherVarName', VariableOperation::ADD, ['type' => 'integer'])],
@@ -158,7 +161,8 @@ class MysqlStatementBuilderTest extends \PHPUnit\Framework\TestCase
                     '`user_defined_function`',
                     'anotherInputValue VARCHAR(32)',
                     'VARCHAR(20)',
-                    'DETERMINISTIC',
+                    'NOT DETERMINISTIC',
+                    'READS SQL DATA',
                     'DECLARE anotherVarName INTEGER;',
                     'RETURN \'foo\';'
                 )


### PR DESCRIPTION
- Adds the readsSqlData property and readsSqlData() method to function migrations.
- The readsSqlData property defaults to false and is therefore backward compatible with previous migrations.
- Updates migration engine to add READS SQL DATA declaration to functions if readsSqlData === true.
- Updates all applicable tests to validate template and migration functions.

To test:
Run any previous function migration, it should behave as expected.
Add or edit a function migration to include the readsSqlData(true) chain method, and the resulting function should include the READS SQL DATA setting.