### PR TITLE
[ENHANCEMENT] Add support for context in migrations

### DIFF
--- a/src/Util/Finder.php
+++ b/src/Util/Finder.php
@@ -4,8 +4,22 @@ namespace Exo\Util;
 
 use Exo\History;
 
-class Finder
-{
+class Finder {
+
+    /**
+     * @var array
+     */
+    private $context;
+
+    /**
+     * Finder constructor.
+     * @param array $context
+     */
+    public function __construct(array $context = [])
+    {
+        $this->context = $context;
+    }
+
     /**
      * Builds a migration history from a filesystem path.
      *
@@ -31,11 +45,23 @@ class Finder
             }
 
             $version = pathinfo($entry, PATHINFO_FILENAME);
-            $migration = require($path . '/' . $entry);
+            $migration = $this->requireFile($path . '/' . $entry);
 
             $history->add($version, $migration);
         }
 
         return $history;
+    }
+
+    /**
+     * Requires a file with context extracted into the local symbol table.
+     *
+     * @param string $filepath
+     * @return mixed
+     */
+    public function requireFile(string $filepath)
+    {
+        extract($this->context);
+        return require($filepath);
     }
 }

--- a/src/Util/Finder.php
+++ b/src/Util/Finder.php
@@ -61,7 +61,9 @@ class Finder {
      */
     public function requireFile(string $filepath)
     {
-        extract($this->context);
+        if (!empty($this->context)) {
+            extract($this->context);
+        }
         return require($filepath);
     }
 }

--- a/src/Util/Finder.php
+++ b/src/Util/Finder.php
@@ -4,7 +4,8 @@ namespace Exo\Util;
 
 use Exo\History;
 
-class Finder {
+class Finder
+{
 
     /**
      * @var array

--- a/tests/Migrations/20200605_create_user_counts_view_with_context.php
+++ b/tests/Migrations/20200605_create_user_counts_view_with_context.php
@@ -1,0 +1,7 @@
+<?php
+
+// Note: A more likely use case is to throw an exception if context is undefined, but this works fine for a test case.
+$tenant_database_name = $tenant_database_name ?? 'undefined';
+
+return Exo\ViewMigration::alter('user_counts')
+    ->withBody("select count(distinct id) as user_count from `${tenant_database_name}`.`users`");

--- a/tests/Util/FinderTest.php
+++ b/tests/Util/FinderTest.php
@@ -2,6 +2,8 @@
 
 namespace Exo\Util;
 
+use Exo\Operation\ViewOperation;
+
 class FinderTest extends \PHPUnit\Framework\TestCase
 {
     public function testFromPath()
@@ -15,12 +17,51 @@ class FinderTest extends \PHPUnit\Framework\TestCase
             '20190905_alter_users',
             '20190912_create_posts',
             '20200602_create_user_counts_view',
-            '20200604_create_user_level_function'
+            '20200604_create_user_level_function',
+            '20200605_create_user_counts_view_with_context'
         ], $history->getVersions());
         $this->assertEquals('users', $operations[0]->getName());
         $this->assertEquals('users', $operations[1]->getName());
         $this->assertEquals('posts', $operations[2]->getName());
         $this->assertEquals('user_counts', $operations[3]->getName());
         $this->assertEquals('user_level', $operations[4]->getName());
+    }
+
+    public function testFromPathWithContextHappyPath()
+    {
+        $finder = new Finder([
+            'tenant_database_name' => 'contextual_database_name'
+        ]);
+        $history = $finder->fromPath(__DIR__ . '/../Migrations');
+        $operations = $history->play('20200605_create_user_counts_view_with_context', '20200605_create_user_counts_view_with_context');
+
+        /* @var ViewOperation $operation */
+        $operation = $operations[0];
+
+        $this->assertEquals('user_counts', $operation->getName());
+        $this->assertEquals('alter', $operation->getOperation());
+
+        $this->assertEquals(
+            'select count(distinct id) as user_count from `contextual_database_name`.`users`',
+            $operation->getBody()
+        );
+    }
+
+    public function testFromPathWithContextSadPath()
+    {
+        $finder = new Finder([]);
+        $history = $finder->fromPath(__DIR__ . '/../Migrations');
+        $operations = $history->play('20200605_create_user_counts_view_with_context', '20200605_create_user_counts_view_with_context');
+
+        /* @var ViewOperation $operation */
+        $operation = $operations[0];
+
+        $this->assertEquals('user_counts', $operation->getName());
+        $this->assertEquals('alter', $operation->getOperation());
+
+        $this->assertEquals(
+            'select count(distinct id) as user_count from `undefined`.`users`',
+            $operation->getBody()
+        );
     }
 }


### PR DESCRIPTION
**Summary:**
Abandons previous implementation of context enabled migrations (which added context support at the handler and Migration levels) in favor of this much simpler approach, which allows context to be passed into the finder and extracts the values thereof into the symbol table at the time the migrations are read in, allowing for simple interpolation.

**Pros/Cons with Change**
Previous approach implemented twig templating for readability withExpectedContext() for testing/validation; so the Con is that this approach leaves migrations a bit more open to developer error, but the pros of the implementation being dead simple seem far outweigh these cons by far.

Thanks to @joshmcrae for the insight/simpler implementation!