### PR TITLE
[HOTFIX] - Correctly handle indexes in reduced table operations

### DIFF
--- a/src/Operation/TableOperation.php
+++ b/src/Operation/TableOperation.php
@@ -299,29 +299,31 @@ class TableOperation extends AbstractOperation
 
                 $indexes[$indexOperation->getName()] = $indexOperation;
             }
+        }
 
-            // Remove non-existent columns from indexes
-            foreach ($indexes as $name => $index) {
-                $indexColumns = [];
-                foreach ($index->getColumns() as $indexColumn) {
-                    foreach ($columns as $column) {
-                        if ($column->getName() === $indexColumn) {
-                            $indexColumns[] = $indexColumn;
-                        }
+        // Remove non-existent columns from indexes
+        foreach ($indexes as $name => $index) {
+            $indexColumns = [];
+
+            foreach ($index->getColumns() as $indexColumn) {
+                foreach ($columns as $column) {
+                    if ($column->getName() === $indexColumn) {
+                        $indexColumns[] = $indexColumn;
                     }
                 }
-
-                if (empty($indexColumns)) {
-                    continue;
-                }
-
-                $indexes[$name] = new IndexOperation(
-                    $index->getName(),
-                    $index->getOperation(),
-                    $indexColumns,
-                    $index->getOptions()
-                );
             }
+
+            if ($index->getOperation() === IndexOperation::ADD && empty($indexColumns)) {
+                unset($indexes[$name]);
+                continue;
+            }
+
+            $indexes[$name] = new IndexOperation(
+                $index->getName(),
+                $index->getOperation(),
+                $indexColumns,
+                $index->getOptions()
+            );
         }
 
         return new TableOperation(

--- a/tests/Operation/TableOperationTest.php
+++ b/tests/Operation/TableOperationTest.php
@@ -171,4 +171,22 @@ class TableOperationTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($create, $operation);
     }
+
+    public function testDropColumnReferencedByIndex()
+    {
+        $base = new TableOperation('users_roles', TableOperation::CREATE, [
+            new ColumnOperation('user_id', ColumnOperation::ADD, ['type' => 'uuid']),
+            new ColumnOperation('role', ColumnOperation::ADD, ['type' => 'string']),
+            new ColumnOperation('deleted_at', ColumnOperation::ADD, ['type' => 'datetime'])
+        ], [
+            new IndexOperation('user_role', IndexOperation::ADD, ['user_id', 'role', 'deleted_at'], [])
+        ]);
+
+        $alter = new TableOperation('users_roles', TableOperation::ALTER, [
+            new ColumnOperation('deleted_at', ColumnOperation::DROP, [])
+        ], []);
+
+        $operation = $base->apply($alter);
+        $this->assertNotContains('deleted_at', $operation->getIndexOperations()[0]->getColumns());
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where index operations are not updated to account for non-existent columns in reduced table operations. This is best demonstrated when a table alteration which drops a given column is applied to a table creation where the column is included in an index.

```php

$create = \Exo\Migration::create('users_roles')
    ->addColumn('user_id', ['type' => 'uuid'])
    ->addColumn('role', ['type' => 'string'])
    ->addColumn('deleted_at', ['type' => 'datetime'])
    ->addIndex('user_role', ['user_id', 'role', 'deleted_at']);

$alter = \Exo\Migration::alter('event_details')
    ->dropColumn('deleted_at');

$operation = $create->apply($alter);
```

The resulting operation should create the index `user_role` using only the `user_id` and `role` columns, since `deleted_at` is never created. Instead it includes all columns and fails to execute against the database.

There was existing code to handle this situation when the base operation alters a table. This has been extracted out of the conditional which checks between create and alter table operations, and enhanced to remove any index creation operations that do not reference any exist existing columns. In cases where a subset of the index' columns will be present, the index operation remains with the available columns.