### PR TITLE
[HOTFIX] - Fix application of column operations within `TableOperation`

### DIFF
--- a/src/Operation/TableOperation.php
+++ b/src/Operation/TableOperation.php
@@ -287,6 +287,14 @@ final class TableOperation extends AbstractOperation implements ReversibleOperat
                 // Apply new column operation
                 switch ($columnOperation->getOperation()) {
                     case ColumnOperation::ADD:
+                        if ($originalOperation == ColumnOperation::DROP) {
+                            $columnOperation = new ColumnOperation(
+                                $columnOperation->getName(),
+                                ColumnOperation::MODIFY,
+                                $columnOperation->getOptions()
+                            );
+                        }
+
                         $columns[] = $columnOperation;
                         break;
                     case ColumnOperation::DROP:
@@ -317,9 +325,11 @@ final class TableOperation extends AbstractOperation implements ReversibleOperat
                         break;
                     case ColumnOperation::CHANGE:
                         $columnName = $originalName;
+                        $options = $columnOperation->getOptions();
 
                         if ($originalOperation == ColumnOperation::ADD) {
                             $columnName = $columnOperation->getAfterName();
+                            unset($options['new_name']);
                         }
 
                         if ($originalOperation == ColumnOperation::MODIFY) {
@@ -329,7 +339,7 @@ final class TableOperation extends AbstractOperation implements ReversibleOperat
                         $columns[] = new ColumnOperation(
                             $columnName,
                             $originalOperation,
-                            $columnOperation->getOptions()
+                            $options
                         );
                         break;
                 }

--- a/src/Operation/TableOperation.php
+++ b/src/Operation/TableOperation.php
@@ -310,7 +310,7 @@ final class TableOperation extends AbstractOperation implements ReversibleOperat
                         }
 
                         $columns[] = new ColumnOperation(
-                            $columnOperation->getName(),
+                            $originalName,
                             $originalOperation,
                             $options
                         );

--- a/src/Operation/TableOperation.php
+++ b/src/Operation/TableOperation.php
@@ -316,7 +316,7 @@ final class TableOperation extends AbstractOperation implements ReversibleOperat
                         );
                         break;
                     case ColumnOperation::CHANGE:
-                        $columnName = $columnOperation->getName();
+                        $columnName = $originalName;
 
                         if ($originalOperation == ColumnOperation::ADD) {
                             $columnName = $columnOperation->getAfterName();

--- a/tests/Operation/TableOperationTest.php
+++ b/tests/Operation/TableOperationTest.php
@@ -86,62 +86,6 @@ class TableOperationTest extends TestCase
         $this->assertEquals(['unique' => true], $operation->getIndexOperations()[0]->getOptions());
     }
 
-    public function testApplyAlterToAlterWithColumnChange()
-    {
-        $base = new TableOperation('users', TableOperation::ALTER, [
-            new ColumnOperation('id', ColumnOperation::DROP, []),
-            new ColumnOperation('email', ColumnOperation::ADD, ['type' => 'string', 'length' => 255, 'first' => true]),
-            new ColumnOperation('username', ColumnOperation::ADD, ['type' => 'string', 'length' => 255])
-        ], [
-            new IndexOperation('email_username', ColumnOperation::ADD, ['email', 'username'], ['unique' => true])
-        ]);
-
-        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
-            new ColumnOperation('email', ColumnOperation::DROP, []),
-            new ColumnOperation('username', ColumnOperation::CHANGE, ['type' => 'string', 'length' => 255, 'new_name' => 'email'])
-        ], []));
-
-        $this->assertEquals('users', $operation->getName());
-        $this->assertEquals(TableOperation::ALTER, $operation->getOperation());
-        $this->assertCount(2, $operation->getColumnOperations());
-        $this->assertCount(1, $operation->getIndexOperations());
-
-        $this->assertEquals('id', $operation->getColumnOperations()[0]->getName());
-        $this->assertEquals(ColumnOperation::DROP, $operation->getColumnOperations()[0]->getOperation());
-
-        $this->assertEquals('email', $operation->getColumnOperations()[1]->getName());
-        $this->assertEquals(ColumnOperation::ADD, $operation->getColumnOperations()[1]->getOperation());
-        $this->assertEquals(['type' => 'string', 'length' => 255, 'new_name' => 'email'], $operation->getColumnOperations()[1]->getOptions());
-
-        $this->assertEquals('email_username', $operation->getIndexOperations()[0]->getName());
-        $this->assertEquals(IndexOperation::ADD, $operation->getIndexOperations()[0]->getOperation());
-        $this->assertEquals(['email'], $operation->getIndexOperations()[0]->getColumns());
-        $this->assertEquals(['unique' => true], $operation->getIndexOperations()[0]->getOptions());
-    }
-
-    public function testApplyAlterToAlterWithModifyColumnChange()
-    {
-        $base = new TableOperation('users', TableOperation::ALTER, [
-            new ColumnOperation('id', ColumnOperation::DROP, []),
-            new ColumnOperation('email', ColumnOperation::CHANGE, ['new_name' => 'username', 'type' => 'string', 'length' => 255, 'first' => true]),
-        ], []);
-
-        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
-            new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'char', 'length' => 64])
-        ], []));
-
-        $this->assertEquals('users', $operation->getName());
-        $this->assertEquals(TableOperation::ALTER, $operation->getOperation());
-        $this->assertCount(2, $operation->getColumnOperations());
-
-        $this->assertEquals('id', $operation->getColumnOperations()[0]->getName());
-        $this->assertEquals(ColumnOperation::DROP, $operation->getColumnOperations()[0]->getOperation());
-
-        $this->assertEquals('email', $operation->getColumnOperations()[1]->getName());
-        $this->assertEquals(ColumnOperation::CHANGE, $operation->getColumnOperations()[1]->getOperation());
-        $this->assertEquals(['type' => 'char', 'length' => 64, 'new_name' => 'username'], $operation->getColumnOperations()[1]->getOptions());
-    }
-
     public function testApplyDropToAlter()
     {
         $base = new TableOperation('users', TableOperation::ALTER, [
@@ -154,6 +98,161 @@ class TableOperationTest extends TestCase
 
         $operation = $base->apply($drop);
         $this->assertEquals($drop, $operation);
+    }
+
+    public function testApplyColumnDropToColumnAdd()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::ADD, ['type' => 'string', 'length' => 255, 'first' => true]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::DROP, []),
+        ], []));
+
+        $this->assertCount(0, $operation->getColumnOperations());
+    }
+
+    public function testApplyColumnModifyToColumnAdd()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::ADD, ['type' => 'string', 'length' => 255, 'first' => true]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::MODIFY, ['type' => 'char', 'length' => 64]),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::ADD, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnChangeToColumnAdd()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::ADD, ['type' => 'string', 'length' => 255, 'first' => true]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::CHANGE, ['type' => 'char', 'length' => 64, 'new_name' => 'username']),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('username', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::ADD, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnAddToColumnDrop()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::DROP, []),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::ADD, ['type' => 'string']),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::MODIFY, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'string'], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnDropToColumnModify()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::DROP, []),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::DROP, $operation->getColumnOperations()[0]->getOperation());
+    }
+
+    public function testApplyColumnModifyToColumnModify()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::MODIFY, ['type' => 'char', 'length' => 64]),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::MODIFY, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnChangeToColumnModify()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::MODIFY, ['type' => 'string', 'length' => 255]),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::CHANGE, ['type' => 'char', 'length' => 64, 'new_name' => 'username']),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::CHANGE, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64, 'new_name' => 'username'], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnDropToColumnChange()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::CHANGE, ['type' => 'string', 'length' => 255, 'new_name' => 'username']),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('username', ColumnOperation::DROP, []),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::DROP, $operation->getColumnOperations()[0]->getOperation());
+    }
+
+    public function testApplyColumnModifyToColumnChange()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::CHANGE, ['type' => 'string', 'length' => 255, 'new_name' => 'username']),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('username', ColumnOperation::MODIFY, ['type' => 'char', 'length' => 64]),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::CHANGE, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64, 'new_name' => 'username'], $operation->getColumnOperations()[0]->getOptions());
+    }
+
+    public function testApplyColumnChangeToColumnChange()
+    {
+        $base = new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('email', ColumnOperation::CHANGE, ['type' => 'string', 'length' => 255, 'new_name' => 'username']),
+        ], []);
+
+        $operation = $base->apply(new TableOperation('users', TableOperation::ALTER, [
+            new ColumnOperation('username', ColumnOperation::CHANGE, ['type' => 'char', 'length' => 64, 'new_name' => 'user_id']),
+        ], []));
+
+        $this->assertCount(1, $operation->getColumnOperations());
+        $this->assertEquals('email', $operation->getColumnOperations()[0]->getName());
+        $this->assertEquals(ColumnOperation::CHANGE, $operation->getColumnOperations()[0]->getOperation());
+        $this->assertEquals(['type' => 'char', 'length' => 64, 'new_name' => 'user_id'], $operation->getColumnOperations()[0]->getOptions());
     }
 
     public function testReverseCreate()


### PR DESCRIPTION
This PR adds more comprehensive tests for `TableOperation` and fixes some bugs with the application of column operations when altering tables. Specifically, the following scenarios were identified and fixed:

1. Applying the addition of a column to the dropping of same column (now results in a column modification)
2. Applying the modification of a column to any operation on that same column uses the original column name (instead of the new name if renamed)
3. Applying the change of a column to any column operation on the same column uses that column's original name. In the case of an add, we clean up the `new_name` option on the column operation since it is not relevant.